### PR TITLE
Improve compatibility with other libraries

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "php": ">=7.4",
         "illuminate/console": ">=7.0",
         "illuminate/support": ">=7.0",
-        "psr/log": "^1.0"
+        "psr/log": "^1.0|^2.0|^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.1",


### PR DESCRIPTION
Hello,
This PR helps compatibility with third party libraries that often requires psr/log 1, 2 or 3.
For example, a fresh Laravel 9 install uses psr/log version 3. 
Thanks for the package,
Karel